### PR TITLE
Helper type to extract valid keys from container instance

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -36,6 +36,14 @@ export type ContainerToken = typeof CONTAINER;
 
 type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
+type ReturnTypeOfFactories<T> = T extends { factories: infer R } ? R : never;
+
+/**
+ * Helper type for extracting valid keys from a container instance
+ */
+export type ContainerKeys<T> = keyof ReturnTypeOfFactories<T>;
+
+
 /**
  * Represents the dependency injection container that manages the registration,
  * creation, and retrieval of services. The Container class is central to


### PR DESCRIPTION
Given a container instance, I want to have interfaces that require a valid type from the container.

I could create MyServices type of valid keys, pass it to the container and then require a keyof MyServices.. but it's easier to allow the container to build the types and extract it from it:

```
interface MyServices {
  foo: number;
  bar: string;
}
type ValidServices = keyof MyServices;

interface Plugin {
  key: ValidServices;
}

const container = new Container<MyServices>({})

```

vs

```
const container = new Container({})

type ValidServices = ContainerKeys<typeof container>;

interface Plugin {
  key: ValidServices;
}


```

Similar to other helpers such as:
https://react-typescript-cheatsheet.netlify.app/docs/react-types/componentprops/#infer-component-props-type