### PR TITLE
Make ClassInjectable infer dependency types. Update docs with an example that compiles.

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -512,9 +512,12 @@ export class Container<Services = {}> {
       ConcatInjectable(fn.token, () => this.providesService(fn).get(fn.token))
     ) as Container<Services>;
 
-  private providesService<Token extends TokenType, Tokens extends readonly ValidTokens<Services>[], Service>(
-    fn: InjectableFunction<Services, Tokens, Token, Service>
-  ): Container<AddService<Services, Token, Service>> {
+  private providesService<
+    Token extends TokenType,
+    Tokens extends readonly ValidTokens<Services>[],
+    Service,
+    Dependencies,
+  >(fn: InjectableFunction<Dependencies, Tokens, Token, Service>): Container<AddService<Services, Token, Service>> {
     const token = fn.token;
     const dependencies: readonly any[] = fn.dependencies;
     // If the service depends on itself, e.g. in the multi-binding case, where we call append multiple times with

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -105,27 +105,27 @@ export function Injectable(
  *
  * @example
  * ```ts
- * class InjectableClassService {
- *   static dependencies = ["service"] as const;
- *   constructor(public service: string) {}
- *   public print(): void {
- *     console.log(this.service);
+ * class Logger {
+ *   static dependencies = ["config"] as const;
+ *   constructor(private config: string) {}
+ *   public print() {
+ *     console.log(this.config);
  *   }
  * }
  *
- * const container = Container.providesValue("service", "service value").provides(
- *   ClassInjectable("classService", InjectableClassService)
- * );
+ * const container = Container
+ *   .providesValue("config", "value")
+ *   .provides(ClassInjectable("logger", Logger));
  *
- * container.get("classService").print(); // prints "service value"
+ * container.get("logger").print(); // prints "value"
  * ```
  *
- * Prefer using Container's provideClass method. Above is the equivalent of:
+ * It is recommended to use the `Container.provideClass()` method. The example above is equivalent to:
  * ```ts
- * const container = Container.provides("service", "service value")
- *     .providesClass("classService", InjectableClassService);
- *
- * container.get("classService").print(); // prints "service value"
+ * const container = Container
+ *   .providesValue("config", "value")
+ *   .providesClass("logger", Logger);
+ * container.get("logger").print(); // prints "value"
  * ```
  *
  * @param token Token identifying the Service.

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -106,20 +106,23 @@ export function Injectable(
  * @example
  * ```ts
  * class InjectableClassService {
- *     static dependencies = ["service"] as const;
- *     constructor(public service: string) {}
- *     public print(): string {
- *          console.log(this.service);
- *     }
+ *   static dependencies = ["service"] as const;
+ *   constructor(public service: string) {}
+ *   public print(): void {
+ *     console.log(this.service);
+ *   }
  * }
  *
- * let container = Container.provides("service", "service value")
- *      .provides(ClassInjectable("classService", InjectableClassService));
+ * const container = Container.providesValue("service", "service value").provides(
+ *   ClassInjectable("classService", InjectableClassService)
+ * );
  *
  * container.get("classService").print(); // prints "service value"
+ * ```
  *
- * // prefer using Container's provideClass method. Above is the equivalent of:
- * container = Container.provides("service", "service value")
+ * Prefer using Container's provideClass method. Above is the equivalent of:
+ * ```ts
+ * const container = Container.provides("service", "service value")
  *     .providesClass("classService", InjectableClassService);
  *
  * container.get("classService").print(); // prints "service value"
@@ -128,10 +131,15 @@ export function Injectable(
  * @param token Token identifying the Service.
  * @param cls InjectableClass to instantiate.
  */
-export function ClassInjectable<Services, Token extends TokenType, const Tokens extends readonly TokenType[], Service>(
+export function ClassInjectable<
+  Class extends InjectableClass<any, any, any>,
+  Dependencies extends ConstructorParameters<Class>,
+  Token extends TokenType,
+  Tokens extends Class["dependencies"],
+>(
   token: Token,
-  cls: InjectableClass<Services, Service, Tokens>
-): InjectableFunction<Services, Tokens, Token, Service>;
+  cls: Class
+): InjectableFunction<ServicesFromTokenizedParams<Tokens, Dependencies>, Tokens, Token, ConstructorReturnType<Class>>;
 
 export function ClassInjectable(
   token: TokenType,
@@ -230,3 +238,5 @@ export function ConcatInjectable(
   factory.dependencies = [token, ...dependencies];
   return factory;
 }
+
+export type ConstructorReturnType<T> = T extends new (...args: any) => infer C ? C : any;

--- a/src/PartialContainer.ts
+++ b/src/PartialContainer.ts
@@ -1,6 +1,6 @@
 import { entries } from "./entries";
-import { memoize } from "./memoize";
 import type { Memoized } from "./memoize";
+import { memoize } from "./memoize";
 import type { Container } from "./Container";
 import type {
   AddService,
@@ -10,9 +10,8 @@ import type {
   TokenType,
   ValidTokens,
 } from "./types";
+import type { ConstructorReturnType } from "./Injectable";
 import { ClassInjectable, Injectable } from "./Injectable";
-
-type ConstructorReturnType<T> = T extends new (...args: any) => infer C ? C : any;
 
 // Using a conditional type forces TS language services to evaluate the type -- so when showing e.g. type hints, we
 // will see the mapped type instead of the AddDependencies type alias. This produces better hints.


### PR DESCRIPTION
Addresses https://github.com/Snapchat/ts-inject/issues/8, examples from the docs now compile, also makes ClassInjectable usable directly as it now infers class's dependencies.