### PR TITLE
Added InjectableCompat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snap/ts-inject",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@snap/ts-inject",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snap/ts-inject",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "100% typesafe dependency injection framework for TypeScript projects",
   "license": "MIT",
   "author": "Snap Inc.",

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -101,6 +101,30 @@ export function Injectable(
 }
 
 /**
+ * A compatibility version of {@link Injectable} for TypeScript 4 and earlier users.
+ * This function behaves identically to {@link Injectable} but requires the use of `as const` on the dependencies array.
+ *
+ * @deprecated Use {@link Injectable} instead. This function is provided for compatibility with TypeScript 4
+ * and earlier versions and will be removed in future releases.
+ *
+ * @see {@link Injectable} for detailed usage instructions and examples.
+ */
+export function InjectableCompat<
+  Token extends TokenType,
+  Tokens extends readonly TokenType[],
+  Params extends readonly any[],
+  Service,
+>(
+  token: Token,
+  dependencies: Tokens,
+  fn: (...args: Tokens["length"] extends Params["length"] ? Params : void[]) => Service
+): Tokens["length"] extends Params["length"]
+  ? InjectableFunction<ServicesFromTokenizedParams<Tokens, Params>, Tokens, Token, Service>
+  : never {
+  return Injectable(token, dependencies, fn);
+}
+
+/**
  * Creates an Injectable factory function for an InjectableClass.
  *
  * @example

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -28,11 +28,8 @@ export function Injectable<Token extends TokenType, Service>(
  * The dependencies are specified as tokens, and the factory function
  * will receive these dependencies as arguments in the order they are listed.
  *
- * **Note:** Dependencies must be specified as constant literals to allow TypeScript to ensure type safety.
- *
- * **Note:** Starting with TypeScript version 5, the `as const` assertion in the example below is not needed
- * due to the introduction of [const type parameters feature](
- * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters).
+ * **Important:** This function requires **TypeScript 5 or later** due to the use of `const` type parameters.
+ * Users on TypeScript 4 and earlier must use {@link InjectableCompat} instead.
  *
  * @example
  * ```ts

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -115,9 +115,7 @@ export function InjectableCompat<
   token: Token,
   dependencies: Tokens,
   fn: (...args: Tokens["length"] extends Params["length"] ? Params : void[]) => Service
-): Tokens["length"] extends Params["length"]
-  ? InjectableFunction<ServicesFromTokenizedParams<Tokens, Params>, Tokens, Token, Service>
-  : never {
+): ReturnType<typeof Injectable> {
   return Injectable(token, dependencies, fn);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { CONTAINER, Container } from "./Container";
-export { Injectable, ConcatInjectable } from "./Injectable";
+export { Injectable, InjectableCompat, ConcatInjectable } from "./Injectable";
 export { PartialContainer } from "./PartialContainer";
 export { InjectableFunction, InjectableClass, ServicesFromInjectables } from "./types";


### PR DESCRIPTION
Addresses https://github.com/Snapchat/ts-inject/issues/10

Users of TS4 and earlier can now use `InjectableCompat` to be able to specify dependencies tuple.