### PR TITLE
Refactored some types to avoid "as" casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ db.save("user2"); // Log: Saving record: user2
 - **Service**: Any value or instance provided by the Container.
 - **Token**: A unique identifier for each service, used for registration and retrieval within the Container.
 - **InjectableFunction**: Functions that return service instances. They can include dependencies which are injected when the service is requested.
-- **InjectableClass**: Classes that can be instantiated by the Container. Dependencies should be specified in a static "dependencies" field to enable proper injection.
 
 ### API Reference
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snap/ts-inject",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@snap/ts-inject",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snap/ts-inject",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "100% typesafe dependency injection framework for TypeScript projects",
   "license": "MIT",
   "author": "Snap Inc.",

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -524,30 +524,18 @@ export class Container<Services = {}> {
    * specified by the token.
    */
   append = <
-  Token extends keyof Services,
-  Tokens extends readonly ValidTokens<Services>[],
-  // Fn extends {
-  //   (...args: Params): ArrayElement<Services[Token]>;
-  //   token: Token;
-  //   dependencies: Tokens;
-  // },
-  Fn extends InjectableFunction<Services, Tokens, Token, ArrayElement<Services[Token]>>,
-  Params extends MapTokensToTypes<Services, Fn["dependencies"]>,
-  Deps extends ServicesFromTokenizedParams<Tokens, Params>
+    Token extends keyof Services,
+    Tokens extends readonly ValidTokens<Services>[],
+    Fn extends {
+      (...args: Params): ArrayElement<Services[Token]>;
+      token: Token;
+      dependencies: Tokens;
+    },
+    Params extends MapTokensToTypes<Services, Fn["dependencies"]>,
   >(
-    fn: Fn
-  ): Container<AddService<Services, Token, ArrayElement<Services[Token]>[]>> => {
-    type ee = Fn["dependencies"];
-    const i = ConcatInjectable<
-      Token,
-      Tokens,
-      Params,
-      ArrayElement<Services[Token]>[],
-      Deps
-    >(fn.token, fn.dependencies, (...args) => fn(...args));
-    const p = this.providesService(i);
-    return p;
-  };
+    fn: Tokens extends readonly TokenType[] ? Fn : never
+  ): Container<AddService<Services, Token, ArrayElement<Services[Token]>[]>> =>
+    this.providesService(ConcatInjectable(fn.token, fn.dependencies, (...args: Params) => fn(...args)));
 
   private providesService<
     Token extends TokenType,

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -420,15 +420,15 @@ export class Container<Services = {}> {
   providesClass = <
     Token extends TokenType,
     Tokens extends readonly ValidTokens<Services>[],
-    Class extends {
-      readonly dependencies: Tokens;
-      new (...args: Params): InstanceType<Class>;
-    },
-    Params extends MapTokensToTypes<Services, Class["dependencies"]>,
+    Params extends MapTokensToTypes<Services, Tokens>,
+    Service
   >(
     token: Token,
-    cls: Class
-  ): Container<AddService<Services, Token, InstanceType<Class>>> =>
+    cls: {
+      readonly dependencies: Tokens;
+      new (...args: Params): Service;
+    }
+  ): Container<AddService<Services, Token, Service>> =>
     this.providesService(Injectable(token, cls.dependencies, (...args: Params) => new cls(...args)));
 
   /**
@@ -486,15 +486,15 @@ export class Container<Services = {}> {
   appendClass = <
     Token extends keyof Services,
     Tokens extends readonly ValidTokens<Services>[],
-    Class extends {
-      readonly dependencies: Tokens;
-      new (...args: Params): InstanceType<Class>;
-    },
-    Params extends MapTokensToTypes<Services, Class["dependencies"]>,
+    Params extends MapTokensToTypes<Services, Tokens>,
+    Service
   >(
     token: Token,
-    cls: Class
-  ): Container<AddService<Services, Token, InstanceType<Class>[]>> =>
+    cls: {
+      readonly dependencies: Tokens;
+      new (...args: Params): Service;
+    }
+  ): Container<AddService<Services, Token, Service[]>> =>
     this.providesService(ConcatInjectable(token, cls.dependencies, (...args: Params) => new cls(...args)));
 
   /**

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -421,7 +421,7 @@ export class Container<Services = {}> {
     Token extends TokenType,
     Tokens extends readonly ValidTokens<Services>[],
     Params extends MapTokensToTypes<Services, Tokens>,
-    Service
+    Service,
   >(
     token: Token,
     cls: {
@@ -487,7 +487,7 @@ export class Container<Services = {}> {
     Token extends keyof Services,
     Tokens extends readonly ValidTokens<Services>[],
     Params extends MapTokensToTypes<Services, Tokens>,
-    Service
+    Service,
   >(
     token: Token,
     cls: {

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -1,17 +1,8 @@
 import type { Memoized } from "./memoize";
 import { isMemoized, memoize } from "./memoize";
 import { PartialContainer } from "./PartialContainer";
-import type {
-  AddService,
-  AddServices,
-  MapTokensToTypes,
-  InjectableFunction,
-  TokenType,
-  ValidTokens,
-  ServicesFromTokenizedParams,
-} from "./types";
+import type { AddService, AddServices, MapTokensToTypes, InjectableFunction, TokenType, ValidTokens } from "./types";
 import { ConcatInjectable, Injectable } from "./Injectable";
-import { entries } from "./entries";
 
 type MaybeMemoizedFactories<Services> = {
   [K in keyof Services]: (() => Services[K]) | Memoized<() => Services[K]>;
@@ -150,8 +141,8 @@ export class Container<Services = {}> {
    * defines the initial set of services to be contained within the new Container instance.
    * @returns A new Container instance populated with the provided services.
    */
-  static fromObject<Services extends { [s: string]: any }>(services: Services): Container<Services> {
-    return entries(services).reduce(
+  static fromObject<Services extends { [s: TokenType]: any }>(services: Services): Container<Services> {
+    return Object.entries(services).reduce(
       (container, [token, value]) => container.providesValue(token, value),
       new Container({})
     ) as Container<Services>;

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -56,15 +56,13 @@ export function Injectable<Token extends TokenType, Service>(
 export function Injectable<
   Token extends TokenType,
   const Tokens extends readonly TokenType[],
+  // The function arity (number of arguments) must match the number of dependencies specified
   Params extends readonly any[] & { length: Tokens["length"] },
   Service,
   Deps extends ServicesFromTokenizedParams<Tokens, Params>,
 >(
   token: Token,
   dependencies: Tokens,
-  // The function arity (number of arguments) must match the number of dependencies specified – if they don't, we'll
-  // force a compiler error by saying the arguments should be `void[]`. We'll also throw at runtime, so the return
-  // type will be `never`.
   fn: (...args: Params) => Service
 ): InjectableFunction<Deps, Tokens, Token, Service>;
 

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -56,18 +56,17 @@ export function Injectable<Token extends TokenType, Service>(
 export function Injectable<
   Token extends TokenType,
   const Tokens extends readonly TokenType[],
-  Params extends readonly any[],
+  Params extends readonly any[] & { length: Tokens["length"] },
   Service,
+  Deps extends ServicesFromTokenizedParams<Tokens, Params>,
 >(
   token: Token,
   dependencies: Tokens,
   // The function arity (number of arguments) must match the number of dependencies specified – if they don't, we'll
   // force a compiler error by saying the arguments should be `void[]`. We'll also throw at runtime, so the return
   // type will be `never`.
-  fn: (...args: Tokens["length"] extends Params["length"] ? Params : void[]) => Service
-): Tokens["length"] extends Params["length"]
-  ? InjectableFunction<ServicesFromTokenizedParams<Tokens, Params>, Tokens, Token, Service>
-  : never;
+  fn: (...args: Params) => Service
+): InjectableFunction<Deps, Tokens, Token, Service>;
 
 export function Injectable(
   token: TokenType,
@@ -79,11 +78,12 @@ export function Injectable(
 
   if (!fn) {
     throw new TypeError(
-      "[Injectable] Received invalid arguments. The factory function must be either the second " + "or third argument."
+      "[Injectable] Received invalid arguments. The factory function must be either the second or third argument."
     );
   }
 
-  if (fn.length !== dependencies.length) {
+  // const length = actualLength in fn ? fn[actualLength] as number : fn.length;
+  if (fn.length !== 0 && fn.length !== dependencies.length) {
     throw new TypeError(
       "[Injectable] Function arity does not match the number of dependencies. Function has arity " +
         `${fn.length}, but ${dependencies.length} dependencies were specified.` +
@@ -219,12 +219,13 @@ export function ConcatInjectable<Token extends TokenType, Service>(
 export function ConcatInjectable<
   Token extends TokenType,
   const Tokens extends readonly TokenType[],
-  Params extends readonly any[],
+  Params extends readonly any[] & { length: Tokens["length"] },
   Service,
+  Deps extends ServicesFromTokenizedParams<Tokens, Params>,
 >(
   token: Token,
   dependencies: Tokens,
-  fn: (...args: Tokens["length"] extends Params["length"] ? Params : void[]) => Service
+  fn: (...args: Params) => Service
 ): InjectableFunction<ServicesFromTokenizedParams<Tokens, Params>, Tokens, Token, Service[]>;
 
 export function ConcatInjectable(
@@ -242,9 +243,9 @@ export function ConcatInjectable(
     );
   }
 
-  if (fn.length !== dependencies.length) {
+  if (fn.length !== 0 && fn.length !== dependencies.length) {
     throw new TypeError(
-      "[Injectable] Function arity does not match the number of dependencies. Function has arity " +
+      "[ConcatInjectable] Function arity does not match the number of dependencies. Function has arity " +
         `${fn.length}, but ${dependencies.length} dependencies were specified.` +
         `\nDependencies: ${JSON.stringify(dependencies)}`
     );

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -80,7 +80,6 @@ export function Injectable(
     );
   }
 
-  // const length = actualLength in fn ? fn[actualLength] as number : fn.length;
   if (fn.length !== 0 && fn.length !== dependencies.length) {
     throw new TypeError(
       "[Injectable] Function arity does not match the number of dependencies. Function has arity " +

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -205,5 +205,3 @@ export function ConcatInjectable(
   factory.dependencies = [token, ...dependencies];
   return factory;
 }
-
-export type ConstructorReturnType<T> = T extends new (...args: any) => infer C ? C : any;

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -1,4 +1,4 @@
-import type { InjectableClass, InjectableFunction, ServicesFromTokenizedParams, TokenType } from "./types";
+import type { InjectableFunction, ServicesFromTokenizedParams, TokenType } from "./types";
 
 /**
  * Creates an Injectable factory function designed for services without dependencies.
@@ -115,57 +115,6 @@ export function InjectableCompat<
   fn: (...args: Tokens["length"] extends Params["length"] ? Params : void[]) => Service
 ): ReturnType<typeof Injectable> {
   return Injectable(token, dependencies, fn);
-}
-
-/**
- * Creates an Injectable factory function for an InjectableClass.
- *
- * @example
- * ```ts
- * class Logger {
- *   static dependencies = ["config"] as const;
- *   constructor(private config: string) {}
- *   public print() {
- *     console.log(this.config);
- *   }
- * }
- *
- * const container = Container
- *   .providesValue("config", "value")
- *   .provides(ClassInjectable("logger", Logger));
- *
- * container.get("logger").print(); // prints "value"
- * ```
- *
- * It is recommended to use the `Container.provideClass()` method. The example above is equivalent to:
- * ```ts
- * const container = Container
- *   .providesValue("config", "value")
- *   .providesClass("logger", Logger);
- * container.get("logger").print(); // prints "value"
- * ```
- *
- * @param token Token identifying the Service.
- * @param cls InjectableClass to instantiate.
- */
-export function ClassInjectable<
-  Class extends InjectableClass<any, any, any>,
-  Dependencies extends ConstructorParameters<Class>,
-  Token extends TokenType,
-  Tokens extends Class["dependencies"],
->(
-  token: Token,
-  cls: Class
-): InjectableFunction<ServicesFromTokenizedParams<Tokens, Dependencies>, Tokens, Token, ConstructorReturnType<Class>>;
-
-export function ClassInjectable(
-  token: TokenType,
-  cls: InjectableClass<any, any, readonly TokenType[]>
-): InjectableFunction<any, readonly TokenType[], TokenType, any> {
-  const factory = (...args: any[]) => new cls(...args);
-  factory.token = token;
-  factory.dependencies = cls.dependencies;
-  return factory;
 }
 
 /**

--- a/src/PartialContainer.ts
+++ b/src/PartialContainer.ts
@@ -141,7 +141,7 @@ export class PartialContainer<Services = {}, Dependencies = {}> {
    * ```
    *
    * @param token the Token by which the class will be known.
-   * @param cls the class to be provided, must match the InjectableClass type.
+   * @param cls the class to be provided.
    */
   providesClass = <
     Token extends TokenType,

--- a/src/__tests__/Container.spec.ts
+++ b/src/__tests__/Container.spec.ts
@@ -152,6 +152,7 @@ describe("Container", () => {
       }
       const containerWithService = container.providesClass("service", Item);
       expect(containerWithService.get("service")).toEqual(new Item(1));
+      expect(containerWithService.factories.service().value).toBe(1);
     });
 
     test("error if class constructor arity doesn't match dependencies", () => {

--- a/src/__tests__/Injectable.spec.ts
+++ b/src/__tests__/Injectable.spec.ts
@@ -1,6 +1,18 @@
 import { Injectable } from "../Injectable";
 
 describe("Injectable", () => {
+  test("is created with not dependencies specified", () => {
+    expect(() => Injectable("TestService", () => {})).not.toThrow();
+  });
+
+  test("is created with empty array specified", () => {
+    expect(() => Injectable("TestService", [], () => {})).not.toThrow();
+  });
+
+  test("is created with dependency specified", () => {
+    expect(() => Injectable("TestService", ["a"], (_a: number) => {})).not.toThrow();
+  });
+
   describe("when given invalid arguments", () => {
     test("a TypeError is thrown", () => {
       expect(() => Injectable("TestService", [] as any)).toThrowError(TypeError);
@@ -8,8 +20,13 @@ describe("Injectable", () => {
   });
 
   describe("when given a function with arity unequal to the number of dependencies", () => {
-    test("a TypeError is thrown", () => {
+    test("a compilation error is thrown", () => {
+      // @ts-expect-error must fail to compile as the factory function arity doesn't match dependencies array
       expect(() => Injectable("TestService", [] as const, (_: any) => {})).toThrowError(TypeError);
+    });
+
+    test("a TypeError is thrown", () => {
+      expect(() => Injectable("TestService", [] as const, ((_: any) => {}) as any)).toThrowError(TypeError);
     });
   });
 });

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -1,7 +1,3 @@
 // `Object.entries` does not use `keyof` types, so it loses type specificity. We'll fix this with a wrapper.
 export const entries = <T extends { [s: string]: U } | ArrayLike<U>, U>(o: T): Array<[keyof T, T[keyof T]]> =>
   Object.entries(o) as unknown as Array<[keyof T, T[keyof T]]>;
-
-// `Object.fromEntries` similarly does not preserve key types.
-export const fromEntries = <K extends string | number | symbol, V>(entries: ReadonlyArray<[K, V]>): Record<K, V> =>
-  Object.fromEntries(entries) as Record<K, V>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { CONTAINER, Container } from "./Container";
 export { Injectable, InjectableCompat, ConcatInjectable } from "./Injectable";
 export { PartialContainer } from "./PartialContainer";
-export { InjectableFunction, InjectableClass, ServicesFromInjectables } from "./types";
+export { InjectableFunction, ServicesFromInjectables } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,18 +53,6 @@ export type MapTokensToTypes<Services, Tokens extends readonly ValidTokens<Servi
   CorrespondingServices<Services, Tokens>
 >;
 
-/**
- * Represents a class that can be used as an injectable service within a dependency injection {@link Container}.
- * The `InjectableClass` type ensures that the class's dependencies and constructor signature align with
- * the services available in the container, providing strong type safety.
- */
-export type InjectableClass<Services, Service, Tokens> = Tokens extends readonly ValidTokens<Services>[]
-  ? {
-      readonly dependencies: Tokens;
-      new (...args: AsTuple<CorrespondingServices<Services, Tokens>>): Service;
-    }
-  : never;
-
 export type AnyInjectable = InjectableFunction<any, readonly TokenType[], TokenType, any>;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,17 @@ export type InjectableFunction<
     }
   : never;
 
+/**
+ * Maps a tuple of tokens to their corresponding service types based on the given Services type mapping.
+ *
+ * @example
+ * ```typescript
+ * type Services = { foo: string; bar: number; };
+ * type Tokens = ['foo', 'bar'];
+ * type Result = MapTokensToTypes<Services, Tokens>;
+ * // Result is [string, number]
+ * ```
+ */
 export type MapTokensToTypes<Services, Tokens extends readonly ValidTokens<Services>[]> = AsTuple<
   CorrespondingServices<Services, Tokens>
 >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,11 +43,15 @@ export type InjectableFunction<
   Service,
 > = Tokens extends readonly ValidTokens<Services>[]
   ? {
-      (...args: AsTuple<CorrespondingServices<Services, Tokens>>): Service;
+      (...args: MapTokensToTypes<Services, Tokens>): Service;
       token: Token;
       dependencies: Tokens;
     }
   : never;
+
+export type MapTokensToTypes<Services, Tokens extends readonly ValidTokens<Services>[]> = AsTuple<
+  CorrespondingServices<Services, Tokens>
+>;
 
 /**
  * Represents a class that can be used as an injectable service within a dependency injection {@link Container}.


### PR DESCRIPTION
The new "as" casting bothered me when we started to explicitly specify return types of `provide*`/`append*` methods and I decided to dig into why `providesService` doesn't return a type that we expect. This PR is the result of this. No broken unit tests, so the expectations remain the same.

I want to do similar cleanup to PartialContainer, but that might be don in another PR.