### PR TITLE
Add providesWith method to Container for chaining with PartialContainer

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -326,6 +326,41 @@ export class Container<Services = {}> {
   }
 
   /**
+   * Provides a PartialContainer and allows extracting its services to append or extend the container
+   * in a single chained call. This avoids breaking the chain when you need to fulfill a partial
+   * container just to extract dependencies for appends.
+   *
+   * @example
+   * ```ts
+   * const featureContainer = Container
+   *   .providesValue('eventHandlers', [] as EventHandler[])
+   *   .providesWith(partialContainer, (fullContainer) =>
+   *     fullContainer.append(
+   *       Injectable(eventHandlersToken, () => fullContainer.get('eventHandlerFromPartialContainer'))
+   *     )
+   *   )
+   *   .provides(...)
+   * ```
+   *
+   * @param partialContainer The PartialContainer to provide and fulfill.
+   * @param callback A function that receives the fulfilled container (this + partialContainer)
+   *                 and returns the modified container (e.g. with appends applied).
+   * @returns The container returned by the callback.
+   */
+  providesWith<
+    PartialServices,
+    PartialDependencies,
+    FulfilledDependencies extends PartialDependencies,
+    ResultServices,
+  >(
+    this: Container<FulfilledDependencies>,
+    partialContainer: PartialContainer<PartialServices, PartialDependencies>,
+    callback: (
+      fullContainer: Container<AddServices<Services, PartialServices>>
+    ) => Container<ResultServices>
+  ): Container<ResultServices>;
+
+  /**
    * Merges additional services from a given `PartialContainer` into this container,
    * creating a new `Container` instance. Services defined in the `PartialContainer` take precedence
    * in the event of token conflicts, meaning any service in the `PartialContainer` with the same token
@@ -405,6 +440,15 @@ export class Container<Services = {}> {
       } as unknown as MaybeMemoizedFactories<AddServices<Services, AdditionalServices>>);
     }
     return this.providesService(fnOrContainer);
+  }
+
+  providesWith<PartialServices, PartialDependencies, FulfilledDependencies, ResultServices>(
+    this: Container<FulfilledDependencies>,
+    partialContainer: PartialContainer<PartialServices, PartialDependencies>,
+    callback: (fullContainer: Container<AddServices<Services, PartialServices>>) => Container<ResultServices>
+  ): Container<ResultServices> {
+    const fullContainer = this.provides(partialContainer);
+    return callback(fullContainer);
   }
 
   /**

--- a/src/__tests__/Container.spec.ts
+++ b/src/__tests__/Container.spec.ts
@@ -226,6 +226,67 @@ describe("Container", () => {
     });
   });
 
+  describe("when using providesWith to provide a PartialContainer and extract dependencies in a single chain", () => {
+    test("provides the partial container and passes fulfilled container to callback", () => {
+      const eventHandlersToken = "eventHandlers" as const;
+      const pluginToken = "plugin" as const;
+
+      const partialContainer = new PartialContainer({})
+        .provides(Injectable(pluginToken, () => "plugin-from-partial"));
+
+      const result = Container.providesValue(eventHandlersToken, [] as string[])
+        .providesWith(partialContainer, (fullContainer) => {
+          expect(fullContainer.get(pluginToken)).toBe("plugin-from-partial");
+          return fullContainer.append(
+            Injectable(eventHandlersToken, () => fullContainer.get(pluginToken))
+          );
+        });
+
+      expect(result.get(pluginToken)).toBe("plugin-from-partial");
+      expect(result.get(eventHandlersToken)).toEqual(["plugin-from-partial"]);
+    });
+
+    test("allows chaining further provides after providesWith", () => {
+      const eventHandlersToken = "eventHandlers" as const;
+      const pluginToken = "plugin" as const;
+      const extraToken = "extra" as const;
+
+      const partialContainer = new PartialContainer({})
+        .provides(Injectable(pluginToken, () => "plugin-value"));
+
+      const result = Container.providesValue(eventHandlersToken, [] as string[])
+        .providesWith(partialContainer, (fullContainer) =>
+          fullContainer.append(
+            Injectable(eventHandlersToken, () => fullContainer.get(pluginToken))
+          )
+        )
+        .providesValue(extraToken, "extra-value");
+
+      expect(result.get(pluginToken)).toBe("plugin-value");
+      expect(result.get(eventHandlersToken)).toEqual(["plugin-value"]);
+      expect(result.get(extraToken)).toBe("extra-value");
+    });
+
+    test("callback can perform multiple appends using extracted services", () => {
+      const pluginsToken = "plugins" as const;
+      const serviceAToken = "serviceA" as const;
+      const serviceBToken = "serviceB" as const;
+
+      const partialContainer = new PartialContainer({})
+        .provides(Injectable(serviceAToken, () => "A"))
+        .provides(Injectable(serviceBToken, () => "B"));
+
+      const result = Container.providesValue(pluginsToken, [] as string[])
+        .providesWith(partialContainer, (fullContainer) =>
+          fullContainer
+            .append(Injectable(pluginsToken, () => fullContainer.get(serviceAToken)))
+            .append(Injectable(pluginsToken, () => fullContainer.get(serviceBToken)))
+        );
+
+      expect(result.get(pluginsToken)).toEqual(["A", "B"]);
+    });
+  });
+
   describe("when appending a Service to an existing array of Services", () => {
     test("appends value to the array", () => {
       const container = Container.providesValue("service", [] as number[])


### PR DESCRIPTION
This commit introduces the `providesWith` method to the `Container` class, allowing users to provide a `PartialContainer` and extract its services in a single chained call. This enhancement simplifies the process of appending or extending the container without breaking the chain. 

Additionally, new tests have been added to verify the functionality of this method, ensuring it correctly handles service extraction and chaining. Updated documentation reflects this new feature.