### PR TITLE
Shift docs focus to streamlined providesValue/providesClass APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,53 +29,81 @@ This quick start guide demonstrates how to define services, register them in a c
 Define a couple of services. For simplicity, we'll use a `Logger` service and a `Database` service, where `Database` depends on `Logger` for logging purposes.
 
 ```ts
-// Logger service definition
 class Logger {
   log(message: string) {
     console.log(`Log: ${message}`);
   }
 }
 
-// Database service depends on Logger
 class Database {
+  static dependencies = ["Logger"] as const;
   constructor(private logger: Logger) {}
 
   save(record: string) {
     this.logger.log(`Saving record: ${record}`);
-    // Assume record saving logic here
   }
 }
 ```
 
 #### Setting Up the Container
 
-With `ts-inject`, you can easily set up a container to manage these services:
+With `ts-inject`, you can set up a container to manage these services using `providesValue` and `providesClass`:
+
+```ts
+import { Container } from "@snap/ts-inject";
+
+const container = Container
+  .providesValue("Logger", new Logger())
+  .providesClass("Database", Database);
+
+const db = container.get("Database");
+db.save("user1"); // Log: Saving record: user1
+```
+
+#### Custom Factory Functions
+
+When a service needs custom instantiation logic — such as transformation, conditional setup, or isn't a simple class — use `Injectable()` with `.provides()`:
 
 ```ts
 import { Container, Injectable } from "@snap/ts-inject";
 
-// Define Injectable factory functions for services
-const loggerFactory = Injectable("Logger", () => new Logger());
-const databaseFactory = Injectable("Database", ["Logger"] as const, (logger: Logger) => new Database(logger));
-
-// Create a container and register services
-const container = Container.provides(loggerFactory).provides(databaseFactory);
-
-// Now, retrieve the Database service from the container
-const db = container.get("Database");
-db.save("user1"); // Log: Saving record: user1
+const container = Container
+  .providesValue("apiUrl", "https://api.example.com")
+  .provides(Injectable("httpClient", ["apiUrl"], (url: string) => createHttpClient(url)));
 ```
+
+`providesValue` and `providesClass` cover the vast majority of use cases. Reach for `Injectable()` only when you need a factory function with custom logic.
 
 #### Composable Containers
 
 `ts-inject` supports composable containers, allowing you to modularize service registration:
 
 ```ts
-const baseContainer = Container.provides(loggerFactory);
-const appContainer = Container.provides(baseContainer).provide(databaseFactory);
+const baseContainer = Container.providesValue("Logger", new Logger());
+const appContainer = baseContainer.providesClass("Database", Database);
 
-const db: Database = appContainer.get("Database");
+const db = appContainer.get("Database");
 db.save("user2"); // Log: Saving record: user2
+```
+
+You can also bootstrap a container from a plain object with `fromObject`:
+
+```ts
+const configContainer = Container.fromObject({ apiUrl: "https://api.example.com", timeout: 5000 });
+```
+
+#### Multi-Binding
+
+Containers support appending to array-typed services, useful for plugin systems and extensible pipelines:
+
+```ts
+const container = Container
+  .providesValue("plugins", [] as Plugin[])
+  .appendClass("plugins", AuthPlugin)
+  .appendClass("plugins", LoggingPlugin)
+  .appendValue("plugins", { name: "inline", run: () => {} });
+
+container.get("plugins"); // [AuthPlugin, LoggingPlugin, { name: "inline", ... }]
 ```
 
 ### Key Concepts
@@ -84,8 +112,8 @@ db.save("user2"); // Log: Saving record: user2
 - **PartialContainer**: Similar to a Container but allows services to be registered without defining all dependencies upfront. Unlike a regular Container, it does not support retrieving services directly.
 - **Service**: Any value or instance provided by the Container.
 - **Token**: A unique identifier for each service, used for registration and retrieval within the Container.
-- **InjectableFunction**: Functions that return service instances. They can include dependencies which are injected when the service is requested.
-- **InjectableClass**: Classes that can be instantiated by the Container. Dependencies should be specified in a static "dependencies" field to enable proper injection.
+- **InjectableClass**: Classes that can be instantiated by the Container. Dependencies are specified in a static `dependencies` field to enable automatic injection via `providesClass`.
+- **InjectableFunction**: The lower-level primitive used by `Injectable()` to create factory functions with explicit dependency lists. Use this when `providesValue`/`providesClass` don't fit your needs.
 
 ### API Reference
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ With `ts-inject`, you can set up a container to manage these services using `pro
 ```ts
 import { Container } from "@snap/ts-inject";
 
-const container = Container
-  .providesValue("Logger", new Logger())
-  .providesClass("Database", Database);
+const container = Container.providesValue("Logger", new Logger()).providesClass("Database", Database);
 
 const db = container.get("Database");
 db.save("user1"); // Log: Saving record: user1
@@ -67,9 +65,9 @@ When a service needs custom instantiation logic — such as transformation, cond
 ```ts
 import { Container, Injectable } from "@snap/ts-inject";
 
-const container = Container
-  .providesValue("apiUrl", "https://api.example.com")
-  .provides(Injectable("httpClient", ["apiUrl"], (url: string) => createHttpClient(url)));
+const container = Container.providesValue("apiUrl", "https://api.example.com").provides(
+  Injectable("httpClient", ["apiUrl"], (url: string) => createHttpClient(url))
+);
 ```
 
 `providesValue` and `providesClass` cover the vast majority of use cases. Reach for `Injectable()` only when you need a factory function with custom logic.
@@ -97,8 +95,7 @@ const configContainer = Container.fromObject({ apiUrl: "https://api.example.com"
 Containers support appending to array-typed services, useful for plugin systems and extensible pipelines:
 
 ```ts
-const container = Container
-  .providesValue("plugins", [] as Plugin[])
+const container = Container.providesValue("plugins", [] as Plugin[])
   .appendClass("plugins", AuthPlugin)
   .appendClass("plugins", LoggingPlugin)
   .appendValue("plugins", { name: "inline", run: () => {} });

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -45,11 +45,12 @@ type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
  * @example
  *
  * ```ts
- * const fooFactory = Injectable('Foo', () => new Foo())
- * const barFactory = Injectable('Bar', ['Foo'] as const, (foo: Foo) => new Bar(foo))
- * const container = Container.provides(fooFactory).provides(barFactory)
+ * const container = Container
+ *   .providesValue('config', { port: 3000 })
+ *   .providesClass('Logger', Logger)
+ *   .providesClass('Server', Server)
  *
- * const bar = container.get('Bar')
+ * const server = container.get('Server')
  * ```
  */
 export class Container<Services = {}> {
@@ -58,11 +59,9 @@ export class Container<Services = {}> {
    *
    * @example
    * ```ts
-   * // Register a single service
-   * const container = Container.provides(Injectable('Logger', () => new Logger()));
-   *
-   * // Extend container with another container or partial container
-   * const extendedContainer = Container.provide(existingContainer);
+   * // Extend a container with a partial container or another container
+   * const container = Container.provides(existingPartialContainer);
+   * const container2 = Container.provides(existingContainer);
    * ```
    */
   static provides<Services>(container: PartialContainer<Services, {}> | Container<Services>): Container<Services>;
@@ -72,9 +71,12 @@ export class Container<Services = {}> {
    *
    * @example
    * ```ts
-   * // Register a single service with no dependencies
+   * // Register a single service using an InjectableFunction
    * const container = Container.provides(Injectable('Logger', () => new Logger()));
    * ```
+   *
+   * **Tip:** For services without dependencies, prefer
+   * {@link Container.providesValue | providesValue} or {@link Container.providesClass | providesClass}.
    */
   static provides<Token extends TokenType, Service>(
     fn: InjectableFunction<{}, [], Token, Service>
@@ -190,7 +192,7 @@ export class Container<Services = {}> {
    * @example
    * ```ts
    * // Create the original container and provide the UserListService
-   * const originalContainer = Container.provides(Injectable('UserListService', () => new UserListService()));
+   * const originalContainer = Container.providesClass('UserListService', UserListService);
    *
    * // Create a new Container copy with UserListService scoped, allowing for independent user lists
    * const newListContainer = originalContainer.copy(['UserListService']);
@@ -266,7 +268,7 @@ export class Container<Services = {}> {
    *
    * // Setup the main container with a request service and run the initializers
    * const container = Container
-   *   .provides(Injectable("request", () => (url: string) => fetch(url)))
+   *   .providesValue("request", (url: string) => fetch(url))
    *   .run(initializers);
    *
    * // At this point, `initCache` and `setupReporter` have been executed using the `request` service.
@@ -296,7 +298,7 @@ export class Container<Services = {}> {
    * ```ts
    * // Setup a container with a request service and directly run the `initCache` service
    * const container = Container
-   *   .provides(Injectable("request", () => (url: string) => fetch(url)))
+   *   .providesValue("request", (url: string) => fetch(url))
    *   .run(Injectable("initCache", ["request"], (request: Request) => fetchAndPopulateCache(request)));
    *
    * // At this point, `initCache` has been executed using the `request` service.

--- a/src/Injectable.ts
+++ b/src/Injectable.ts
@@ -4,6 +4,10 @@ import type { InjectableClass, InjectableFunction, ServicesFromTokenizedParams, 
  * Creates an Injectable factory function designed for services without dependencies.
  * This is useful for simple services or values that don't depend on other parts of the system.
  *
+ * **Tip:** For simple cases, prefer {@link Container.providesValue | Container.providesValue()}
+ * or {@link Container.providesClass | Container.providesClass()} instead. Use `Injectable()` when
+ * you need custom factory logic.
+ *
  * @example
  * ```ts
  * const container = Container.provides(Injectable("MyService", () => new MyService()));

--- a/src/PartialContainer.ts
+++ b/src/PartialContainer.ts
@@ -64,14 +64,14 @@ type PartialContainerFactories<Services> = {
  *
  * Here's an example of PartialContainer usage:
  * ```ts
- * // We can provide fooFactory, even though the PartialContainer doesn't fulfill the Bar dependency.
- * const fooFactory = Injectable('Foo', ['Bar'] as const, (bar: Bar) => new Foo(bar))
- * const partialContainer = new PartialContainer({}).provide(fooFactory)
+ * // We can register Foo, even though the PartialContainer doesn't fulfill the Bar dependency.
+ * const partialContainer = new PartialContainer({})
+ *   .providesClass('Foo', Foo) // Foo declares static dependencies = ['Bar'] as const
  *
- * const barFactory = Injectable('Bar', () => new Bar())
- * const dependenciesContainer = Container.provides(barFactory)
- *
- * const combinedContainer = dependenciesContainer.provides(partialContainer)
+ * // Provide the missing dependency via a Container
+ * const combinedContainer = Container
+ *   .providesValue('Bar', new Bar())
+ *   .provides(partialContainer)
  *
  * // We can resolve Foo, because the combined container includes Bar, so all of Foo's dependencies are now met.
  * const foo = combinedContainer.get('Foo')


### PR DESCRIPTION
## Summary

- Lead README and TSDoc examples with `providesValue`/`providesClass` instead of verbose `Injectable()` factory pattern
- Present `Injectable()` as an escape hatch for custom factory logic
- Add "Custom Factory Functions" and "Multi-Binding" sections to README
- Add `fromObject` example to "Composable Containers"
- Fix `.provide` typo in Composable Containers example
- Reorder "Key Concepts" to emphasize `InjectableClass` over `InjectableFunction`
- Update TSDoc examples in `Container.ts`, `PartialContainer.ts`, and `Injectable.ts` to match

## Test plan

- [x] `npm run build` — compiles and regenerates docs without errors
- [x] `npm test` — all 56 tests pass (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)