### PR TITLE
Publish to npm via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -20,6 +23,9 @@ jobs:
         node-version: 20.x
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org/'
+
+    - name: Upgrade npm for Trusted Publishing
+      run: npm install -g npm@latest
 
     - name: Determine pre-release tag
       id: release-tag
@@ -43,6 +49,4 @@ jobs:
       run: npm run compile
 
     - name: Publish
-      run: npm publish --access public --tag ${{ env.tag }}
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --provenance --access public --tag ${{ env.tag }}


### PR DESCRIPTION
## Summary
- Switch the npm publish workflow from a long-lived `NPM_TOKEN` secret to short-lived OIDC tokens via npm Trusted Publishing.
- Grant `id-token: write`, upgrade npm to `@latest` (Trusted Publishing needs npm >= 11.5.1; Node 20 ships with npm 10), drop `NODE_AUTH_TOKEN`, and add `--provenance` for attestation.

## Required setup on npmjs.com
Before the next release tag is pushed, configure `@snap/ts-inject` as a Trusted Publisher:
1. npmjs.com → package settings → **Publishing access** → **Add trusted publisher** → GitHub Actions
2. Org: `Snapchat`, Repo: `ts-inject`, Workflow filename: `npm.yaml`, Environment: blank
3. After the first successful OIDC publish, delete the `NPM_TOKEN` repo secret.

## Test plan
- [ ] Trusted Publisher configured on npmjs.com pointing at `npm.yaml`
- [ ] Re-tag `v1.0.0` and confirm the workflow publishes via OIDC
- [ ] Verify the published version carries a provenance badge
- [ ] Remove `NPM_TOKEN` repo secret after first successful publish