### PR TITLE
Fix memoize re-invoking factories that return undefined

### DIFF
--- a/src/__tests__/Container.spec.ts
+++ b/src/__tests__/Container.spec.ts
@@ -397,6 +397,15 @@ describe("Container", () => {
       const container: Container<{ TestService: string }> = new Container({} as any);
       expect(() => container.get("TestService")).toThrowError('Could not find Service for Token "TestService"');
     });
+
+    test("a factory returning undefined is only invoked once", () => {
+      const factory = jest.fn().mockReturnValue(undefined);
+      const containerWithService = Container.provides("TestService", factory);
+
+      expect(containerWithService.get("TestService")).toBeUndefined();
+      expect(containerWithService.get("TestService")).toBeUndefined();
+      expect(factory).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("when getting the Container Token", () => {

--- a/src/__tests__/memoize.spec.ts
+++ b/src/__tests__/memoize.spec.ts
@@ -1,0 +1,44 @@
+import { isMemoized, memoize } from "../memoize";
+
+describe("memoize", () => {
+  test("invokes the delegate only once and returns the cached result", () => {
+    const delegate = jest.fn().mockReturnValue("value");
+    const memoized = memoize(delegate);
+
+    expect(memoized()).toBe("value");
+    expect(memoized()).toBe("value");
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  test("invokes the delegate only once even when it returns undefined", () => {
+    const delegate = jest.fn().mockReturnValue(undefined);
+    const memoized = memoize(delegate);
+
+    expect(memoized()).toBeUndefined();
+    expect(memoized()).toBeUndefined();
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not cache when the delegate throws, allowing a retry", () => {
+    const delegate = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("first call fails");
+      })
+      .mockReturnValue("recovered");
+    const memoized = memoize(delegate);
+
+    expect(() => memoized()).toThrowError("first call fails");
+    expect(memoized()).toBe("recovered");
+    expect(delegate).toHaveBeenCalledTimes(2);
+  });
+
+  test("exposes the original function via delegate and is detected by isMemoized", () => {
+    const delegate = () => 42;
+    const memoized = memoize(delegate);
+
+    expect(memoized.delegate).toBe(delegate);
+    expect(isMemoized(memoized)).toBe(true);
+    expect(isMemoized(delegate)).toBe(false);
+  });
+});

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -10,10 +10,15 @@ export function isMemoized(fn: unknown): fn is Memoized<AnyFunction> {
 }
 
 export function memoize<Fn extends AnyFunction>(delegate: Fn): Memoized<Fn> {
+  // Track invocation with a flag rather than checking `memo` against `undefined`, so that
+  // factories which legitimately return `undefined` are still only invoked once. The flag is
+  // set only after `delegate` returns, preserving the existing behavior of retrying on throw.
+  let invoked = false;
   let memo: any;
   const memoized = function (this: any, ...args: any[]) {
-    if (typeof memo !== "undefined") return memo;
+    if (invoked) return memo;
     memo = delegate.apply(this, args);
+    invoked = true;
     return memo;
   };
   memoized.delegate = delegate;


### PR DESCRIPTION
## Problem

`memoize()` uses `typeof memo !== "undefined"` as its cache-hit check, so any factory whose result is `undefined` is silently re-invoked on **every** `container.get()` call. This breaks the documented run-once/singleton guarantee — notably for the side-effect initializer pattern the docs recommend with `run()` (e.g. `Injectable("initCache", ["request"], (req) => populateCache(req))`, whose factory returns nothing and therefore re-runs on every subsequent resolution).

Repro:

```ts
let calls = 0;
const c = Container.provides("init", () => { calls++; return undefined; });
c.get("init"); c.get("init"); c.get("init");
// calls === 3, expected 1
```

## Fix

Track invocation with an explicit `invoked` flag instead of inspecting the memoized value. The flag is set only *after* the delegate returns, deliberately preserving the existing retry-on-throw behavior that existing tests rely on.

## Tests

- New `memoize.spec.ts`: undefined-result caching, throw-then-retry, `delegate`/`isMemoized` behavior
- Container-level regression test in `Container.spec.ts`

All tests pass with 100% coverage maintained; ESLint clean.