### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snap/ts-inject",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@snap/ts-inject",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snap/ts-inject",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "100% typesafe dependency injection framework for TypeScript projects",
   "license": "MIT",
   "author": "Snap Inc.",


### PR DESCRIPTION
**Background**
Preparing the v1.0.1 patch release per the release runbook.

**Change**
- Patch version bump via `npm version patch --no-git-tag-version`.

**Test Plan**
- CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)